### PR TITLE
Authentication Patch

### DIFF
--- a/auth-patch.js
+++ b/auth-patch.js
@@ -1,0 +1,61 @@
+// This module should only be used if you are using this
+// server to authenticate AND the owner of json-server-auth
+// has not yet made the necessary changes to add a 'role' to
+// the JWT payload inside the accessToken
+// As of right now, the only team that has made this change is
+// Frontend team C, so this is mainly for them. However, if any
+// of the other teams consolidate all their axios posts to the same
+// URL (local), then this patch will be necessary for you guys too.
+
+// Step 1. npm install
+// Step 2. npm run patch
+// Step 3. Go into db.json and add the following key(s) to
+// the existing users (or create a new one)
+//    Make sure each user has a role and an authFields array, like so:
+// {
+//     "email": "a@a.com",
+//     "password": "$2a$10$3Z83fo3Z/9ZbIUjq4upNo.Eeghwzga9KZiZ0/E4tpZLG95mamhnqy",
+//     "role": "headmaster",
+//     "username": "Amado"
+//     "authFields": ["role", "username"],
+//     "id": 20
+// }
+
+// The role is obvious, but the authFields array indicates which fields will be passed
+// in the JWT payload. (by default the email and id (sub) will already be included)
+
+// --------------------------------------------------------------------------------------
+const fs = require('fs');
+const { join } = require('path');
+
+const jsonServerAuth = join(__dirname, 'node_modules', 'json-server-auth');
+const jsonUsersFile = join(jsonServerAuth, 'dist', 'users.js');
+const jsonRenamedFile = join(jsonServerAuth, 'dist', 'users_old.js');
+const newUsersFile = join(__dirname, 'users.js');
+
+try {
+	if (!fs.existsSync(jsonServerAuth) || !fs.existsSync(jsonUsersFile) || !fs.existsSync(newUsersFile))
+		throw new Error(
+			'Could not find the json-server-auth package. Please make sure you have run npm install before running this script.'
+		);
+
+	if (!fs.existsSync(jsonUsersFile))
+		throw new Error(
+			'Found the json-server-auth package, but could not find the users.js file inside the package. Please re-install the package.'
+		);
+
+	if (!fs.existsSync(newUsersFile))
+		throw new Error('Found the json-server-auth package, but missing the patched users.js file.');
+
+	console.log('Found the json-sever-auth module & the users.js file.');
+
+	console.log('Renaming the existing users.js file in the package to users_old.js (just in case)..');
+	fs.renameSync(jsonUsersFile, jsonRenamedFile);
+
+	console.log('Copying over the patched users.js file into the package..');
+	fs.copyFileSync(newUsersFile, jsonUsersFile);
+
+	console.log('Done. You should be able to run npm start now.');
+} catch (error) {
+	console.log(error);
+}

--- a/auth-patch.js
+++ b/auth-patch.js
@@ -33,6 +33,23 @@ const jsonUsersFile = join(jsonServerAuth, 'dist', 'users.js');
 const jsonRenamedFile = join(jsonServerAuth, 'dist', 'users_old.js');
 const newUsersFile = join(__dirname, 'users.js');
 
+const updateDB = () => {
+	const db = JSON.parse(fs.readFileSync('./db.json'));
+	const { users } = db;
+
+	const newUsers = users.map((user) => {
+		if (user.id >= 16) {
+			user.role = 'headmaster';
+			user.authFields = ['role'];
+		}
+		return user;
+	});
+
+	db.users = newUsers;
+
+	fs.writeFileSync('./db.json', JSON.stringify(db, null, 2));
+};
+
 try {
 	if (!fs.existsSync(jsonServerAuth) || !fs.existsSync(jsonUsersFile) || !fs.existsSync(newUsersFile))
 		throw new Error(
@@ -54,6 +71,11 @@ try {
 
 	console.log('Copying over the patched users.js file into the package..');
 	fs.copyFileSync(newUsersFile, jsonUsersFile);
+
+	console.log(
+		'Making sure that all of the recently created users in the database (id over 16) have the necessary fields...'
+	);
+	updateDB();
 
 	console.log('Done. You should be able to run npm start now.');
 } catch (error) {

--- a/auth-patch.js
+++ b/auth-patch.js
@@ -9,8 +9,6 @@
 
 // Step 1. npm install
 // Step 2. npm run patch
-// Step 3. Go into db.json and add the following key(s) to
-// the existing users (or create a new one)
 //    Make sure each user has a role and an authFields array, like so:
 // {
 //     "email": "a@a.com",

--- a/db.json
+++ b/db.json
@@ -122,6 +122,15 @@
       "email": "teacher@tea.com",
       "password": "$2a$10$r0Msdne1kGtCR1tsCiOH5.44e/dQ0G.AGn3WlKPgIG9OHWY.mPJ2W",
       "id": 19
+    },
+    {
+      "email": "a@a.com",
+      "password": "$2a$10$3Z83fo3Z/9ZbIUjq4upNo.Eeghwzga9KZiZ0/E4tpZLG95mamhnqy",
+      "authFields": [
+        "role"
+      ],
+      "role": "headmaster",
+      "id": 20
     }
   ],
   "teacher": [

--- a/package.json
+++ b/package.json
@@ -1,30 +1,31 @@
 {
-  "name": "mockdb",
-  "version": "1.0.0",
-  "description": "Mock API Data for Labs VBB",
-  "main": "index.js",
-  "engines": {
-    "node": "12.x"
-  },
-  "scripts": {
-    "start": "node server.js",
-    "dev": "json-server-auth db.json -r routes.json --port 5000",
-    "genData": "node dataGenerator.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "prod": "forever start server.js"
-  },
-  "author": "Matthew Mulford",
-  "license": "MIT",
-  "dependencies": {
-    "body-parser": "1.19.0",
-    "cors": "^2.8.5",
-    "faker": "5.1.0",
-    "json-server": "^0.16.3",
-    "json-server-auth": "^2.0.2",
-    "json-server-relationship": "0.14.5",
-    "jsonfile": "6.1.0",
-    "jsonwebtoken": "8.5.1",
-    "nodemon": "2.0.7"
-  },
-  "devDependencies": {}
+	"name": "mockdb",
+	"version": "1.0.0",
+	"description": "Mock API Data for Labs VBB",
+	"main": "index.js",
+	"engines": {
+		"node": "12.x"
+	},
+	"scripts": {
+		"start": "node server.js",
+		"dev": "json-server-auth db.json -r routes.json --port 5000",
+		"patch": "node auth-patch.js",
+		"genData": "node dataGenerator.js",
+		"test": "echo \"Error: no test specified\" && exit 1",
+		"prod": "forever start server.js"
+	},
+	"author": "Matthew Mulford",
+	"license": "MIT",
+	"dependencies": {
+		"body-parser": "1.19.0",
+		"cors": "^2.8.5",
+		"faker": "5.1.0",
+		"json-server": "^0.16.3",
+		"json-server-auth": "^2.0.2",
+		"json-server-relationship": "0.14.5",
+		"jsonfile": "6.1.0",
+		"jsonwebtoken": "8.5.1",
+		"nodemon": "2.0.7"
+	},
+	"devDependencies": {}
 }

--- a/users.js
+++ b/users.js
@@ -1,0 +1,163 @@
+'use strict';
+//test
+var __rest =
+	(this && this.__rest) ||
+	function (s, e) {
+		var t = {};
+		for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0) t[p] = s[p];
+		if (s != null && typeof Object.getOwnPropertySymbols === 'function')
+			for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+				if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i])) t[p[i]] = s[p[i]];
+			}
+		return t;
+	};
+Object.defineProperty(exports, '__esModule', { value: true });
+const bcrypt = require('bcryptjs');
+const express_1 = require('express');
+const jwt = require('jsonwebtoken');
+const shared_middlewares_1 = require('./shared-middlewares');
+const constants_1 = require('./constants');
+/**
+ * Validate email and password
+ */
+const validate = ({ required }) => (req, res, next) => {
+	const { email, password } = req.body;
+	if (required && (!email || !email.trim() || !password || !password.trim())) {
+		res.status(400).jsonp('Email and password are required');
+		return;
+	}
+	if (email && !email.match(constants_1.EMAIL_REGEX)) {
+		res.status(400).jsonp('Email format is invalid');
+		return;
+	}
+	if (password && password.length < constants_1.MIN_PASSWORD_LENGTH) {
+		res.status(400).jsonp('Password is too short');
+		return;
+	}
+	next();
+};
+/**
+ * Register / Create a user
+ */
+const create = (req, res, next) => {
+	const _a = req.body,
+		{ email, password, authFields } = _a,
+		rest = __rest(_a, ['email', 'password', 'authFields']);
+	const { db } = req.app;
+	const fields = {};
+	if (authFields) authFields.forEach((field) => (fields[field] = req.body[field]));
+	if (db == null) {
+		// json-server CLI expose the router db to the app
+		// (https://github.com/typicode/json-server/blob/master/src/cli/run.js#L74),
+		// but if we use the json-server module API, we must do the same.
+		throw Error('You must bind the router db to the app');
+	}
+	const existingUser = db.get('users').find({ email }).value();
+	if (existingUser) {
+		res.status(400).jsonp('Email already exists');
+		return;
+	}
+	bcrypt
+		.hash(password, constants_1.SALT_LENGTH)
+		.then((hash) => {
+			// Create users collection if doesn't exist,
+			// save password as hash and add any other field without validation
+			try {
+				return db
+					.get('users')
+					.insert(Object.assign({ email, password: hash, authFields }, rest))
+					.write();
+			} catch (error) {
+				throw Error('You must add a "users" collection to your db');
+			}
+		})
+		.then((user) => {
+			return new Promise((resolve, reject) => {
+				jwt.sign(
+					Object.assign({ email }, fields),
+					constants_1.JWT_SECRET_KEY,
+					{ expiresIn: constants_1.JWT_EXPIRES_IN, subject: String(user.id) },
+					(error, idToken) => {
+						if (error) reject(error);
+						else resolve(idToken);
+					}
+				);
+			});
+		})
+		.then((accessToken) => {
+			// Return an access token instead of the user record
+			res.status(201).jsonp({ accessToken });
+		})
+		.catch(next);
+};
+/**
+ * Login
+ */
+const login = (req, res, next) => {
+	const { email, password } = req.body;
+	const { db } = req.app;
+	if (db == null) {
+		throw Error('You must bind the router db to the app');
+	}
+	const user = db.get('users').find({ email }).value();
+	if (!user) {
+		res.status(400).jsonp('Cannot find user');
+		return;
+	}
+	const fields = {};
+	if (user.authFields) user.authFields.forEach((field) => (fields[field] = user[field]));
+	bcrypt
+		.compare(password, user.password)
+		.then((same) => {
+			if (!same) throw 400;
+			return new Promise((resolve, reject) => {
+				jwt.sign(
+					Object.assign({ email }, fields),
+					constants_1.JWT_SECRET_KEY,
+					{ expiresIn: constants_1.JWT_EXPIRES_IN, subject: String(user.id) },
+					(error, idToken) => {
+						if (error) reject(error);
+						else resolve(idToken);
+					}
+				);
+			});
+		})
+		.then((accessToken) => {
+			res.status(200).jsonp({ accessToken });
+		})
+		.catch((err) => {
+			if (err === 400) res.status(400).jsonp('Incorrect password');
+			else next(err);
+		});
+};
+/**
+ * Patch and Put user
+ */
+// TODO: create new access token when password or email changes
+const update = (req, res, next) => {
+	const { password } = req.body;
+	if (!password) {
+		next(); // Simply continue with json-server router
+		return;
+	}
+	bcrypt
+		.hash(password, constants_1.SALT_LENGTH)
+		.then((hash) => {
+			req.body.password = hash;
+			next();
+		})
+		.catch(next);
+};
+/**
+ * Users router
+ */
+exports.default = express_1
+	.Router()
+	.use(shared_middlewares_1.bodyParsingHandler)
+	.post('/users|register|signup', validate({ required: true }), create)
+	// Bypass eventual users guards to still allow creation
+	.post('/[640]{3}/users', validate({ required: true }), create)
+	.post('/login|signin', validate({ required: true }), login)
+	.put('/users/:id', validate({ required: true }), update)
+	.patch('/users/:id', validate({ required: false }), update)
+	.use(shared_middlewares_1.errorHandler);


### PR DESCRIPTION
As I mentioned before, I had to make some changes to the way the authentication is done for my frontend team.

To make up for this, I added a new script in package.json for my team so that as soon as they clone the repo, they can do an `npm install`, `npm run patch`, and `npm start` and their Frontend should still continue to work as intended with the added `role` to the accessToken payload.

Since the other two teams are still using the deployed link to authenticate, this doesn't really affect them and can mostly be ignored. But once my team clones this repo, I want them to be able to start working immediately and not have to worry about the authentication issues. 

As a side note, if your frontend teams decide that they also want to be able to properly authenticate with their local backend (rather than the deployed link), you can also use this script to get it up and working.