### PR TITLE
only backup users file if it isn't already backed up

### DIFF
--- a/auth-patch.js
+++ b/auth-patch.js
@@ -64,8 +64,10 @@ try {
 
 	console.log('Found the json-sever-auth module & the users.js file.');
 
-	console.log('Renaming the existing users.js file in the package to users_old.js (just in case)..');
-	fs.renameSync(jsonUsersFile, jsonRenamedFile);
+	if (!fs.existsSync(jsonRenamedFile)) {
+		console.log('Renaming the existing users.js file in the package to users_old.js (just in case)..');
+		fs.renameSync(jsonUsersFile, jsonRenamedFile);
+	}
 
 	console.log('Copying over the patched users.js file into the package..');
 	fs.copyFileSync(newUsersFile, jsonUsersFile);


### PR DESCRIPTION
Fixed an error from this [PR](https://github.com/Lambda-School-Labs/village-book-builders-b-be/pull/4) where if the users_old.js file already exists, the script will fail. 